### PR TITLE
fix ipynb markdown image links

### DIFF
--- a/Using_datasets_to_support_your_hypothesis.ipynb
+++ b/Using_datasets_to_support_your_hypothesis.ipynb
@@ -1,117 +1,128 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "Using datasets to support your hypothesis.ipynb",
-      "version": "0.3.2",
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/Shayros/Developing-hypotheses/blob/master/Using_datasets_to_support_your_hypothesis.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/Shayros/Developing-hypotheses/blob/master/Using_datasets_to_support_your_hypothesis.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "5nBJgce9ST3D",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "# First task: Using datasets to support your hypothesis\n",
-        "\n",
-        "\n",
-        "---\n",
-        "\n",
-        "The page that we are going to be using  in this project is the [NCBI Gene Expression Ombnibus](https://www.ncbi.nlm.nih.gov/geo/)\n",
-        "\n",
-        "\"GEO is a public functional genomics data repository supporting MIAME-compliant data submissions. Array- and sequence-based data are accepted. Tools are provided to help users query and download experiments and curated gene expression profiles\"\n",
-        "\n",
-        "![NCBI Geo site](https://github.com/Shayros/Developing-hypotheses/blob/master/figures/NCBI%20Geo%20site.png)"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "_90EKkl_yKeC",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        ""
-      ]
-    },
-    {
-      "metadata": {
-        "id": "3A6if_EraEi4",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "#1. Downloading the datasets\n",
-        "\n",
-        "Once you arrived at the site, you are going to search for the things that you would like to study. For instance, you can write in the search breast cancer and all the data available that used breast cancer will show up.\n",
-        "\n",
-        "**As an example I will be using three datasets of RNA-seq expression of lung at different embryonic stage:**\n",
-        "\n",
-        "*GSM2319567 (lung 9.5 embryo expression)\n",
-        "\n",
-        "*GSM3027039 (lung 10.5 embryo expression)\n",
-        "\n",
-        "*GSM3027047 (lung 11.5 embryo expression)\n",
-        "\n",
-        "To download the data you can go to end and dowload the series matrix. GSE files are the one that contain the data to be analyzed and GPL files contain the annotation. When working with your own questions I recommend downloading both to help you know what mRNA data you are analyzing.\n",
-        "\n",
-        "I am going to include the steps to download one of the datasets and save this data to help you find the data when the files are added as a supplement information instead of a series matrix.\n",
-        "\n",
-        "-Look on this data on the search bar\n",
-        "\n",
-        "\n",
-        "-In the bottom of the pages sometimes are instruction that will help you find the data. As you see in the instruction \"Raw data are available in SRA\"\n",
-        "\n",
-        "![Finding the data step one](https://github.com/Shayros/Developing-hypotheses/blob/master/figures/Finding%20the%20data%20step%20one.png)\n",
-        "\n",
-        "-Now, find your dataset!\n",
-        "\n",
-        "![Finding the data step two](https://github.com/Shayros/Developing-hypotheses/blob/master/figures/Finding%20the%20data%20step%20two.png)\n",
-        "\n",
-        "\n",
-        "-Downloading the datasets\n",
-        "\n",
-        "![Finding the data step three](https://github.com/Shayros/Developing-hypotheses/blob/master/figures/Finding%20the%20data%20step%20three.png)\n",
-        "\n",
-        "\n",
-        "-Final step\n",
-        "\n",
-        "![Finding the data last step](https://github.com/Shayros/Developing-hypotheses/blob/master/figures/Finding%20the%20data%20last%20step.png)\n",
-        "\n",
-        "\n",
-        "**You have your data. Now what?**\n",
-        "\n",
-        "-You need to filter the data either in Excel or python to facilitates its use.\n"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "Uno5FQIPuJgx",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "#2. Cleaning information on Excel"
-      ]
-    }
-  ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "5nBJgce9ST3D"
+   },
+   "source": [
+    "# First task: Using datasets to support your hypothesis\n",
+    "\n",
+    "\n",
+    "---\n",
+    "\n",
+    "The page that we are going to be using  in this project is the [NCBI Gene Expression Ombnibus](https://www.ncbi.nlm.nih.gov/geo/)\n",
+    "\n",
+    "\"GEO is a public functional genomics data repository supporting MIAME-compliant data submissions. Array- and sequence-based data are accepted. Tools are provided to help users query and download experiments and curated gene expression profiles\"\n",
+    "\n",
+    "![NCBI Geo site](figures/NCBI%20Geo%20site.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "_90EKkl_yKeC"
+   },
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "3A6if_EraEi4"
+   },
+   "source": [
+    "#1. Downloading the datasets\n",
+    "\n",
+    "Once you arrived at the site, you are going to search for the things that you would like to study. For instance, you can write in the search breast cancer and all the data available that used breast cancer will show up.\n",
+    "\n",
+    "**As an example I will be using three datasets of RNA-seq expression of lung at different embryonic stage:**\n",
+    "\n",
+    "*GSM2319567 (lung 9.5 embryo expression)\n",
+    "\n",
+    "*GSM3027039 (lung 10.5 embryo expression)\n",
+    "\n",
+    "*GSM3027047 (lung 11.5 embryo expression)\n",
+    "\n",
+    "To download the data you can go to end and dowload the series matrix. GSE files are the one that contain the data to be analyzed and GPL files contain the annotation. When working with your own questions I recommend downloading both to help you know what mRNA data you are analyzing.\n",
+    "\n",
+    "I am going to include the steps to download one of the datasets and save this data to help you find the data when the files are added as a supplement information instead of a series matrix.\n",
+    "\n",
+    "-Look on this data on the search bar\n",
+    "\n",
+    "\n",
+    "-In the bottom of the pages sometimes are instruction that will help you find the data. As you see in the instruction \"Raw data are available in SRA\"\n",
+    "\n",
+    "![Finding the data step one](figures/Finding%20the%20data%20step%20one.png)\n",
+    "\n",
+    "-Now, find your dataset!\n",
+    "\n",
+    "![Finding the data step two](figures/Finding%20the%20data%20step%20two.png)\n",
+    "\n",
+    "\n",
+    "-Downloading the datasets\n",
+    "\n",
+    "![Finding the data step three](figures/Finding%20the%20data%20step%20three.png)\n",
+    "\n",
+    "\n",
+    "-Final step\n",
+    "\n",
+    "![Finding the data last step](figures/Finding%20the%20data%20last%20step.png)\n",
+    "\n",
+    "\n",
+    "**You have your data. Now what?**\n",
+    "\n",
+    "-You need to filter the data either in Excel or python to facilitates its use.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Uno5FQIPuJgx"
+   },
+   "source": [
+    "#2. Cleaning information on Excel"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "include_colab_link": true,
+   "name": "Using datasets to support your hypothesis.ipynb",
+   "provenance": [],
+   "version": "0.3.2"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
Hi @Shayros,

Thanks for filing this issue: https://github.com/marskar/biof309_fall2018/issues/10

The problem with the images in the markdown cells of your Jupyter notebook is that you used urls to pages showing the images on GitHub instead of paths to the image themselves.

I removed everything before `figures`in the links to turn the urls into relative paths* to your images in the `figures` folder in the repo. 

If you merge this pull request, all of the images in the notebook should work. Here's a link to what the notebook looks like after the fix: https://github.com/marskar/Developing-hypotheses/blob/master/Using_datasets_to_support_your_hypothesis.ipynb

Cheers,
Martin

*A relative path is relative to your repo in the sense that the highest level of the repo is the starting point of everything. 
Here is the structure of your repo with the dot representing the top-level starting point:
```
.
├── LICENSE
├── README.md
├── Using_datasets_to_support_your_hypothesis.ipynb
├── figures
│   ├── Finding\ the\ data\ last\ step.png
│   ├── Finding\ the\ data\ step\ one.png
│   ├── Finding\ the\ data\ step\ three.png
│   ├── Finding\ the\ data\ step\ two.png
│   ├── NCBI\ Geo\ site.png
│   ├── Searching\ for\ your\ mRNA\ in\ Excel.png
│   └── info\ of\ the\ figures
└── notebooks
    └── info\ of\ the\ notebooks
```